### PR TITLE
Add retries in case of non-OK status codes and raise error for non-OK status codes on first page

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,6 +75,9 @@
     "ts-node": "^8.5.4",
     "typescript": "^4.9.5"
   },
+  "overrides": {
+    "chrome-har": "^0.14.0"
+  },
   "config": {
     "commitizen": {
       "path": "./node_modules/cz-conventional-changelog"

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "typescript": "^4.9.5"
   },
   "overrides": {
-    "chrome-har": "^0.14.0"
+    "chrome-har": "^1.0.1"
   },
   "config": {
     "commitizen": {

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -303,10 +303,13 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
         }
         const browse_links = sampleSize(subDomainLinks, args.numPages);
         output.browsing_history = [output.uri_dest].concat(browse_links.map(l => l.href));
-        console.log('About to browse more links');
+        console.log(`About to browse ${browse_links?.length} more links`);
 
-        for (const link of output.browsing_history.slice(1)) {
-            logger.log('info', `browsing now to ${link}`, { type: 'Browser' });
+        let successUrls = 0;
+        let failedUrls = 0;
+
+        for (const [idx, link] of output.browsing_history.slice(1).entries()) {
+            logger.log('info', `[#${idx + 2}] browsing now to ${link}`, { type: 'Browser' });
             if (didBrowserDisconnect) {
                 return {
                     status: 'failed',
@@ -316,7 +319,7 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
             if (args.clearCache) {
                 await clearCookiesCache(page);
             }
-            console.log(`Browsing now to ${link}`);
+            console.log(`[#${idx + 2}] Browsing now to ${link}`);
             
             const linkSuccess = await navigateWithTimeout(page, link, args.defaultTimeout, args.defaultWaitUntil as PuppeteerLifeCycleEvent);
 
@@ -329,8 +332,13 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
                 await autoScroll(page);
 
                 pageIndex++;
+                successUrls++;
+            } else {
+                failedUrls++;
             }
         }
+
+        console.log(`Finished browsing website. ${successUrls} pages browsed successfully, ${failedUrls} failed.`);
 
         await captureBrowserCookies(page, args.outDir);
         if (args.captureHar) {

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -190,33 +190,68 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
         }
 
         // Function to navigate to a page with a timeout guard
-        const navigateWithTimeout = async (page: Page, url: string, timeout: number, waitUntil: PuppeteerLifeCycleEvent) => {
-            try {
-                page_response = await Promise.race([
-                    page.goto(url, {
-                        timeout: timeout,
-                        waitUntil: waitUntil
-                    }),
-                    new Promise((_, reject) =>
-                        setTimeout(() => {
-                            console.log('First navigation attempt timeout');
-                            reject(new Error('First navigation attempt timeout'));
-                        }, 10000)
-                    )
-                ]);
-            } catch (error) {
-                console.log('First attempt failed, trying with domcontentloaded');
-                page_response = await page.goto(url, {
-                    timeout: timeout,
-                    waitUntil: 'domcontentloaded' as PuppeteerLifeCycleEvent
-                });
+        const navigateWithTimeout = async (page: Page, url: string, timeout: number, waitUntil: PuppeteerLifeCycleEvent, maxRetries: number = 3) => {
+            let lastResponse = null;
+            
+            for (let attempt = 1; attempt <= maxRetries; attempt++) {
+                try {
+                    page_response = await Promise.race([
+                        page.goto(url, {
+                            timeout: timeout,
+                            waitUntil: waitUntil
+                        }),
+                        new Promise((_, reject) =>
+                            setTimeout(() => {
+                                console.log(`Navigation attempt ${attempt} timeout`);
+                                reject(new Error(`Navigation attempt ${attempt} timeout`));
+                            }, 10000)
+                        )
+                    ]);
+                } catch (error) {
+                    console.log(`Attempt ${attempt} failed, trying with domcontentloaded`);
+                    try {
+                        page_response = await page.goto(url, {
+                            timeout: timeout,
+                            waitUntil: 'domcontentloaded' as PuppeteerLifeCycleEvent
+                        });
+                    } catch (fallbackError) {
+                        console.log(`Attempt ${attempt} failed completely: ${fallbackError.message}`);
+                        if (attempt === maxRetries) {
+                            return false;
+                        }
+                        continue;
+                    }
+                }
+                
+                lastResponse = page_response;
+                
+                // Check if the response status is 2xx (OK)
+                if (page_response && page_response.status() >= 200 && page_response.status() < 300) {
+                    await savePageContent(pageIndex, args.outDir, page, args.saveScreenshots);
+                    return true;
+                } else {
+                    console.log(`Attempt ${attempt} - HTTP status: ${page_response?.status()} for ${url}`);
+                    if (attempt < maxRetries) {
+                        console.log(`Retrying navigation to ${url} (attempt ${attempt + 1}/${maxRetries})`);
+                        await new Promise(resolve => setTimeout(resolve, 1000)); // Wait 1 second before retry
+                    }
+                }
             }
-            await savePageContent(pageIndex, args.outDir, page, args.saveScreenshots);
+            
+            console.log(`Skipping page ${url} after ${maxRetries} attempts - final HTTP status: ${lastResponse?.status()}`);
+            return false;
         };
 
         // Go to the first url
         console.log('Going to the first url', inUrl);
-        await navigateWithTimeout(page, inUrl, args.defaultTimeout, args.defaultWaitUntil as PuppeteerLifeCycleEvent);
+        const firstPageSuccess = await navigateWithTimeout(page, inUrl, args.defaultTimeout, args.defaultWaitUntil as PuppeteerLifeCycleEvent);
+        
+        if (!firstPageSuccess) {
+            return {
+                status: 'failed',
+                page_response: `Initial page returned non-2xx status: ${page_response?.status()}`
+            };
+        }
         
         // Save landing page title
         const title = await page.title();
@@ -283,16 +318,18 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
             }
             console.log(`Browsing now to ${link}`);
             
-            await navigateWithTimeout(page, link, args.defaultTimeout, args.defaultWaitUntil as PuppeteerLifeCycleEvent);
+            const linkSuccess = await navigateWithTimeout(page, link, args.defaultTimeout, args.defaultWaitUntil as PuppeteerLifeCycleEvent);
 
-            await fillForms(page);
+            if (linkSuccess) {
+                await fillForms(page);
 
-            await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for 1 second
+                await new Promise(resolve => setTimeout(resolve, 1000)); // Wait for 1 second
 
-            duplicatedLinks = duplicatedLinks.concat(await getLinks(page));
-            await autoScroll(page);
+                duplicatedLinks = duplicatedLinks.concat(await getLinks(page));
+                await autoScroll(page);
 
-            pageIndex++;
+                pageIndex++;
+            }
         }
 
         await captureBrowserCookies(page, args.outDir);


### PR DESCRIPTION
#### What does this PR do?
Add retries in case of non-OK status codes and raise error for non-OK status codes on first page

#### Why are we doing this? How does it help us?
Allows to filter blocked responses such as CloudFlare causing incorrect results.

#### How/where should this be tested?
Any website that uses Cloudflare for protection.

#### What are potential areas for future improvement? Are there any dependencies (especially on 3rd party code)?
N/A

#### What are the relevant tickets, tasks, or documents?
N/A

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [x] Tested manually
* [x] Checked for performance implications? *( )*
* [x] Checked for security vulnerabilities? *( )*
* [x] Added/updated documentation? *( )*
* [x] Added/updated tests