### PR TITLE
[FIX] Handle 304 not modified for webpage responses

### DIFF
--- a/__tests__/inspector.ts
+++ b/__tests__/inspector.ts
@@ -1,0 +1,101 @@
+import puppeteer from 'puppeteer';
+import { defaultPuppeteerBrowserOptions } from '../src/pptr-utils/default';
+import { setupBlacklightInspector } from '../src/inspectors/inspector';
+import { BlacklightEvent, Global } from '../src/types';
+declare var global: Global;
+
+jest.setTimeout(30000);
+
+describe('setupBlacklightInspector SKIP_VALUE_SYMBOLS', () => {
+  let browser: puppeteer.Browser;
+
+  beforeAll(async () => {
+    browser = await puppeteer.launch(defaultPuppeteerBrowserOptions);
+  });
+
+  afterAll(async () => {
+    await browser.close();
+  });
+
+  it('strips value for window.localStorage symbols', async () => {
+    const events: BlacklightEvent[] = [];
+    const page = await browser.newPage();
+
+    await setupBlacklightInspector(page, event => events.push(event), true);
+    await page.goto('about:blank');
+
+    await page.evaluate(() => {
+      (window as any).reportEvent(JSON.stringify({
+        type: 'JsInstrument.ObjectProperty',
+        url: 'http://example.com',
+        stack: [],
+        data: { symbol: 'window.localStorage', value: 'sensitive-data', operation: 'get' },
+      }));
+    });
+
+    await page.close();
+    const match = events.find(e => (e as any).data?.symbol === 'window.localStorage');
+    expect(match).toBeDefined();
+    expect((match as any).data.value).toBe('[SKIPPED]');
+  });
+
+  it('strips value for window.sessionStorage symbols', async () => {
+    const events: BlacklightEvent[] = [];
+    const page = await browser.newPage();
+
+    await setupBlacklightInspector(page, event => events.push(event), true);
+    await page.goto('about:blank');
+
+    await page.evaluate(() => {
+      (window as any).reportEvent(JSON.stringify({
+        type: 'JsInstrument.ObjectProperty',
+        url: 'http://example.com',
+        stack: [],
+        data: { symbol: 'window.sessionStorage', value: 'sensitive-data', operation: 'get' },
+      }));
+    });
+
+    await page.close();
+    const match = events.find(e => (e as any).data?.symbol === 'window.sessionStorage');
+    expect(match).toBeDefined();
+    expect((match as any).data.value).toBe('[SKIPPED]');
+  });
+
+  it('preserves value for non-skipped symbols', async () => {
+    const events: BlacklightEvent[] = [];
+    const page = await browser.newPage();
+
+    await setupBlacklightInspector(page, event => events.push(event), true);
+    await page.goto('about:blank');
+
+    await page.evaluate(() => {
+      (window as any).reportEvent(JSON.stringify({
+        type: 'JsInstrument.ObjectProperty',
+        url: 'http://example.com',
+        stack: [],
+        data: { symbol: 'document.cookie', value: 'a=1; b=2', operation: 'get' },
+      }));
+    });
+
+    await page.close();
+    const match = events.find(e => (e as any).data?.symbol === 'document.cookie');
+    expect(match).toBeDefined();
+    expect((match as any).data.value).toBe('a=1; b=2');
+  });
+
+  it('emits error event for malformed JSON payload', async () => {
+    const events: BlacklightEvent[] = [];
+    const page = await browser.newPage();
+
+    await setupBlacklightInspector(page, event => events.push(event), true);
+    await page.goto('about:blank');
+
+    await page.evaluate(() => {
+      (window as any).reportEvent('not-valid-json{{{');
+    });
+
+    await page.close();
+    const errorEvent = events.find(e => e.type === 'Error.BlacklightInspector');
+    expect(errorEvent).toBeDefined();
+  });
+});

--- a/__tests__/logger.ts
+++ b/__tests__/logger.ts
@@ -1,0 +1,39 @@
+import { join } from 'path';
+import { mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { getLogger, logHeap } from '../src/helpers/logger';
+
+let tmpDir: string;
+
+beforeAll(() => {
+  tmpDir = join(tmpdir(), `logger-test-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('getLogger', () => {
+  it('returns logger and logFilePath', () => {
+    const result = getLogger({ outDir: tmpDir, quiet: true });
+    expect(result).toHaveProperty('logger');
+    expect(result).toHaveProperty('logFilePath');
+    expect(result.logFilePath).toMatch(/inspection-log\.ndjson$/);
+  });
+
+  it('uses a temp file when outDir is empty', () => {
+    const result = getLogger({ outDir: '', quiet: true });
+    expect(result.logFilePath).toMatch(/-log\.ndjson$/);
+    expect(result.logger).toBeDefined();
+  });
+});
+
+describe('logHeap', () => {
+  it('logs heap usage without throwing', () => {
+    const spy = jest.spyOn(console, 'log').mockImplementation();
+    expect(() => logHeap('test')).not.toThrow();
+    expect(spy).toHaveBeenCalledWith(expect.stringMatching(/\[test\] heapUsed=\d+MB \| heapTotal=\d+MB/));
+    spy.mockRestore();
+  });
+});

--- a/__tests__/stream-events.ts
+++ b/__tests__/stream-events.ts
@@ -1,0 +1,104 @@
+import { join } from 'path';
+import { writeFileSync, mkdirSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { streamEventsByType } from '../src/helpers/stream-events';
+
+const ALL_TESTS = [
+  'cookies',
+  'key_logging',
+  'session_recorders',
+  'third_party_trackers',
+  'fb_pixel_events',
+  'behaviour_event_listeners',
+  'canvas_fingerprinters',
+  'canvas_font_fingerprinters',
+  'fingerprintable_api_calls',
+];
+
+const FIXTURE_LINES = [
+  JSON.stringify({ message: { type: 'JsInstrument.ObjectProperty', url: 'http://example.com', stack: [], data: { symbol: 'document.cookie', value: 'a=1', operation: 'get' } } }),
+  JSON.stringify({ message: { type: 'Cookie.HTTP', url: 'http://example.com', stack: [], data: { name: 'sid', value: 'abc' } } }),
+  JSON.stringify({ message: { type: 'KeyLogging', url: 'http://example.com', stack: [], data: { post_request_url: '', post_data: '', match_type: [], filter: [] } } }),
+  JSON.stringify({ message: { type: 'SessionRecording', url: 'http://example.com', stack: [], data: {} } }),
+  JSON.stringify({ message: { type: 'TrackingRequest', url: 'http://example.com', stack: [], data: {} } }),
+  JSON.stringify({ message: { type: 'JsInstrument.Error', url: 'http://example.com', stack: [], data: { symbol: 'err', value: '', operation: '' } } }),
+  JSON.stringify({ message: {} }),
+  JSON.stringify({ message: { type: null } }),
+  'this is not valid json',
+  '',
+  JSON.stringify({ message: { type: 'JsInstrument.FunctionProxy', url: 'http://example.com', stack: [], data: { symbol: 'document.addEventListener', value: '[]', operation: 'call' } } }),
+];
+
+let tmpDir: string;
+let fixturePath: string;
+
+beforeAll(() => {
+  tmpDir = join(tmpdir(), `stream-events-test-${Date.now()}`);
+  mkdirSync(tmpDir, { recursive: true });
+  fixturePath = join(tmpDir, 'inspection-log.ndjson');
+  writeFileSync(fixturePath, FIXTURE_LINES.join('\n'));
+});
+
+afterAll(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+});
+
+describe('streamEventsByType', () => {
+  it('routes events to correct buckets', async () => {
+    const buckets = await streamEventsByType(fixturePath, ALL_TESTS);
+
+    // 2 JsInstrument variants + 1 Cookie.HTTP
+    expect(buckets.cookies.length).toBe(3);
+    expect(buckets.cookies.map(e => e.type)).toContain('JsInstrument.ObjectProperty');
+    expect(buckets.cookies.map(e => e.type)).toContain('Cookie.HTTP');
+    expect(buckets.cookies.map(e => e.type)).toContain('JsInstrument.FunctionProxy');
+
+    expect(buckets.key_logging.length).toBe(1);
+    expect(buckets.key_logging[0].type).toBe('KeyLogging');
+
+    expect(buckets.session_recorders.length).toBe(1);
+    expect(buckets.session_recorders[0].type).toBe('SessionRecording');
+
+    expect(buckets.third_party_trackers.length).toBe(1);
+    expect(buckets.third_party_trackers[0].type).toBe('TrackingRequest');
+
+    expect(buckets.fb_pixel_events.length).toBe(1);
+    expect(buckets.fb_pixel_events[0].type).toBe('TrackingRequest');
+
+    // Both JsInstrument variants route to these buckets
+    expect(buckets.behaviour_event_listeners.length).toBe(2);
+    expect(buckets.canvas_fingerprinters.length).toBe(2);
+    expect(buckets.canvas_font_fingerprinters.length).toBe(2);
+    expect(buckets.fingerprintable_api_calls.length).toBe(2);
+  });
+
+  it('filters out Error types', async () => {
+    const buckets = await streamEventsByType(fixturePath, ALL_TESTS);
+    const allEvents = Object.values(buckets).flat();
+    expect(allEvents.every(e => !e.type.includes('Error'))).toBe(true);
+  });
+
+  it('handles only requested tests', async () => {
+    const buckets = await streamEventsByType(fixturePath, ['cookies']);
+
+    expect(buckets.cookies.length).toBe(3);
+    expect(Object.keys(buckets)).toEqual(['cookies']);
+  });
+
+  it('skips malformed and empty lines', async () => {
+    const buckets = await streamEventsByType(fixturePath, ALL_TESTS);
+    const allEvents = Object.values(buckets).flat();
+    expect(allEvents.length).toBeGreaterThan(0);
+    allEvents.forEach(e => {
+      expect(e.type).toBeDefined();
+    });
+  });
+
+  it('returns empty buckets for no matching events', async () => {
+    const emptyPath = join(tmpDir, 'empty.ndjson');
+    writeFileSync(emptyPath, JSON.stringify({ message: { type: 'Cookie.HTTP', url: '', stack: [], data: {} } }));
+
+    const buckets = await streamEventsByType(emptyPath, ['key_logging']);
+    expect(buckets.key_logging).toEqual([]);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@themarkup/blacklight-collector",
-  "version": "3.6.4",
+  "version": "3.6.5",
   "description": "A real-time website privacy inspector.",
   "main": "build/index.js",
   "funding": {

--- a/src/collector.ts
+++ b/src/collector.ts
@@ -225,13 +225,14 @@ export const collect = async (inUrl: string, args: CollectorOptions) => {
                 }
                 
                 lastResponse = page_response;
+                const status = page_response?.status();
                 
-                // Check if the response status is 2xx (OK)
-                if (page_response && page_response.status() >= 200 && page_response.status() < 300) {
+                // Check if the response status is 2xx (OK) or 304 (Not Modified)
+                if (page_response && ((status >= 200 && status < 300) || status === 304)) {
                     await savePageContent(pageIndex, args.outDir, page, args.saveScreenshots);
                     return true;
                 } else {
-                    console.log(`Attempt ${attempt} - HTTP status: ${page_response?.status()} for ${url}`);
+                    console.log(`Attempt ${attempt} - HTTP status: ${status} for ${url}`);
                     if (attempt < maxRetries) {
                         console.log(`Retrying navigation to ${url} (attempt ${attempt + 1}/${maxRetries})`);
                         await new Promise(resolve => setTimeout(resolve, 1000)); // Wait 1 second before retry


### PR DESCRIPTION
#### What does this PR do?
Handle 304 not modified for webpage responses

#### Why are we doing this? How does it help us?
Handle 304 not modified for webpage responses

#### How/where should this be tested?
Websites that return 304 not modified

#### What are potential areas for future improvement? Are there any dependencies (especially on 3rd party code)?
N/A

#### What are the relevant tickets, tasks, or documents?
N/A

#### Have you done the following, if applicable:
***(optional: add explanation between parentheses)***

* [x] Tested manually
* [x] Checked for performance implications? *( )*
* [x] Checked for security vulnerabilities? *( )*
* [x] Added/updated documentation? *( )*
* [x] Added/updated tests